### PR TITLE
Back Button Click to transit the state

### DIFF
--- a/src/resistance_exercise_layer.c
+++ b/src/resistance_exercise_layer.c
@@ -16,6 +16,7 @@ static struct {
     Layer *text_layer;
     ActionBarLayer *action_bar;
     resistance_exercise_t *current_exercise;
+    classification_dismissed_callback_t dismissed;
 } ui;
 
 static struct {
@@ -46,6 +47,7 @@ static void zero() {
     if (selection.timer != NULL) app_timer_cancel(selection.timer);
     selection.timer = NULL;
     action_bar_layer_remove_from_window(ui.action_bar);
+    if (ui.dismissed != NULL) ui.dismissed();
 }
 
 /// sets the main bitmap to be displayed
@@ -211,7 +213,8 @@ static void window_unload(Window *window) {
     gbitmap_destroy(ui.action_down_bitmap);
 }
 
-Window* rex_init(void) {
+Window* rex_init(classification_dismissed_callback_t dismissed) {
+    ui.dismissed = NULL;
     zero();
     ui.bitmap = NULL;
     ui.window = window_create();
@@ -219,6 +222,7 @@ Window* rex_init(void) {
             .load = window_load,
             .unload = window_unload
     });
+    ui.dismissed = dismissed;
 
 #ifdef PBL_COLOR
     window_set_background_color(ui.window, GColorWhite);

--- a/src/resistance_exercise_layer.h
+++ b/src/resistance_exercise_layer.h
@@ -34,6 +34,12 @@ typedef struct __attribute__((__packed__)) {
 typedef void (*classification_accepted_callback_t)(const uint8_t index);
 
 ///
+/// Callback that will be called when the classification UI has been dismissed and
+/// all handlers cleared
+///
+typedef void (*classification_dismissed_callback_t)(void);
+
+///
 /// Callback that will be called when the user rejects the exercise
 ///
 typedef void (*classification_rejected_callback_t)(void);
@@ -64,7 +70,7 @@ void rex_not_moving(void);
 
 void rex_empty(void);
 
-Window* rex_init(void);
+Window* rex_init(classification_dismissed_callback_t dismissed);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
### Description
We used to listen to the __tap__ event for the transition of state, but we find that Pebble's tap event is rather unreliable. Thus, now we will listen to the __back button click__ event for the transition of state.

### Observation

* Even though the transition of state is so much easier via button click, issue #10 remains. Even though the pebble app is showing images for different state, but behind the scene it's actually working correctly.
* If we do not need to check for vibration, we can probably remove things associated with ``bool is_vibrating()``

### Review
* [ ] Ready for review.